### PR TITLE
smtp/mime: Configurable URL scheme extraction v1

### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -236,7 +236,7 @@ SCEnumCharMap smtp_reply_map[ ] = {
 };
 
 /* Create SMTP config structure */
-SMTPConfig smtp_config = { 0, { 0, 0, 0, 0, 0 }, 0, 0, 0, 0, STREAMING_BUFFER_CONFIG_INITIALIZER};
+SMTPConfig smtp_config = { 0, { 0, 0, 0, NULL, 0, 0, 0 }, 0, 0, 0, 0, STREAMING_BUFFER_CONFIG_INITIALIZER};
 
 static SMTPString *SMTPStringAlloc(void);
 

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -309,6 +309,26 @@ static void SMTPConfigure(void) {
             }
 
             smtp_config.mime_config.extract_urls_schemes = extract_urls_schemes;
+        } else {
+            /* Add default extract url scheme 'http' since 
+             * extract-urls-schemes wasn't found in the config */
+            ConfNode *seq_node = ConfNodeNew();
+            ConfNode *scheme = ConfNodeNew();
+            if (unlikely(seq_node == NULL || scheme == NULL)) {
+                exit(EXIT_FAILURE);
+            }
+            seq_node->name = SCStrdup("extract-urls-schemes");
+            scheme->val = SCStrdup("http");
+            if (unlikely(seq_node->name == NULL || scheme->val == NULL)) {
+                exit(EXIT_FAILURE);
+            }
+            seq_node->is_seq = 1;
+            TAILQ_INSERT_TAIL(&seq_node->head, scheme, next);
+            TAILQ_INSERT_TAIL(&config->head, seq_node, next);
+
+            smtp_config.mime_config.extract_urls_schemes = seq_node;
+        }
+
         }
 
         ret = ConfGetChildValueBool(config, "body-md5", &val);

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -329,6 +329,9 @@ static void SMTPConfigure(void) {
             smtp_config.mime_config.extract_urls_schemes = seq_node;
         }
 
+        ret = ConfGetChildValueBool(config, "log-url-scheme", &val);
+        if (ret) {
+            smtp_config.mime_config.log_url_scheme = val;
         }
 
         ret = ConfGetChildValueBool(config, "body-md5", &val);

--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -80,7 +80,7 @@
 #define MAX_IP6_CHARS  39
 
 /* Globally hold configuration data */
-static MimeDecConfig mime_dec_config = { 1, 1, 1, 0, MAX_HEADER_VALUE };
+static MimeDecConfig mime_dec_config = { 1, 1, 1, NULL, 0, 0, MAX_HEADER_VALUE };
 
 /* Mime Parser String translation */
 static const char *StateFlags[] = { "NONE",

--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -70,7 +70,6 @@
 #define QP_STR            "quoted-printable"
 #define TXT_STR           "text/plain"
 #define HTML_STR          "text/html"
-#define URL_STR           "http://"
 
 /* Memory Usage Constants */
 #define STACK_FREE_NODES  10

--- a/src/util-decode-mime.h
+++ b/src/util-decode-mime.h
@@ -65,6 +65,7 @@
 /* Publicly exposed size constants */
 #define DATA_CHUNK_SIZE  3072  /* Should be divisible by 3 */
 #define LINEREM_SIZE      256
+#define URL_SCHEME_SIZE    60  /* Max URL scheme size from config */
 
 /* Mime Parser Constants */
 #define HEADER_READY    0x01

--- a/src/util-decode-mime.h
+++ b/src/util-decode-mime.h
@@ -96,6 +96,9 @@ typedef struct MimeDecConfig {
     int decode_base64;  /**< Decode base64 bodies */
     int decode_quoted_printable;  /**< Decode quoted-printable bodies */
     int extract_urls;  /**< Extract and store URLs in data structure */
+    ConfNode *extract_urls_schemes; /**< List of schemes of which to
+                                         extract urls  */
+    int log_url_scheme; /**< Log the scheme of extracted URLs */
     int body_md5;  /**< Compute md5 sum of body */
     uint32_t header_value_depth;  /**< Depth of which to store header values
                                        (Default is 2000) */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -777,6 +777,12 @@ app-layer:
 
         # Extract URLs and save in state data structure
         extract-urls: yes
+        # Scheme of URLs to extract
+        # (default is [http])
+        #extract-urls-schemes: [http, https, ftp, mailto]
+        # Log the scheme of URLs that are extracted
+        # (default is no)
+        #log-url-scheme: yes
         # Set to yes to compute the md5 of the mail body. You will then
         # be able to journalize it.
         body-md5: no


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
Doesn't seem like any of the other MIME config from suricata.yaml is documented in doc/userguide, adding all these may be another task and might be considered out of scope.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2054

Describe changes:
- adds option 'extract-urls-schemes' to suricata.yaml to specify schemes to extract URLs instead of only 'http://' prefixed URL's getting parsed from mime bodies of SMTP traffic when using 'extract-urls: yes'
- adds option 'log-url-scheme' to suricata.yaml to specify whether to log the scheme portion of the extracted URLs, e.g. log the extra 'http://' prefix along with URLs

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable): N/A, Passed except for 1 test case from libhtp??
prscript/buildbot run on feature branch:::::

[----------] Global test environment tear-down
[==========] 338 tests from 15 test cases ran. (3438 ms total)
[  PASSED  ] 337 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] ConnectionParsing.CompressedResponseChunked

 1 FAILED TEST
FAIL test_all (exit status: 1)

